### PR TITLE
Add a simple white noise generator

### DIFF
--- a/white_noise_generator.phyphox
+++ b/white_noise_generator.phyphox
@@ -1,0 +1,54 @@
+<phyphox xmlns="https://phyphox.org/xml" version="1.19">
+  <title>White noise generator</title>
+  <category>Acoustics</category>
+  <icon format="base64">iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAABQhSURBVHic7Z17sF1Vfce/K4EQCBDCQx4BCY/Q8JbykGfxUZC0SCmDSB1FxIGhVAqipB1G7DDUEUGEAgrTVixFh0IdkZeIFgc0SGOEmUiA8gwgCY9ANAECuXl8+sc+93LY53fvPXuffdY6Z5/f58+171nre/bd37Me+7d+S3Icx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3Ecx3EcxykAsD1wI7Bfai2O0zMAk4BzgBVkzAVCal1OFwB2B74B3AHcDJwJbJRaV68CzAQW0cqJqbU5FQOcDawx/tnPAnum1teLAOsBj4xyzzZIrc+pCOAs45/czHPAJql19iLAMaPcs3NTa3MqoPEPXj2OQQC+lFprrwLcbdyvZcAWqbU5HQDsDSxvwxwAd6fW26uQzd2sH5lvptbmlATYBni+TXMAzE+tuZcB/s24Z6uAGam1OQUBNgQeLGAOgN+m1t3LAFvz7lJvM9el1uYUAAjATQXN4QZpA+Ai474NATun1ua0Cdl7jjK4QcYBmAq8bty776XW5rQB8LmS5nCDtAlwgXHv1gB/klqbMwbAkWSTRjdIFwGmAK8Y9897kV4FmEW2Lt8JbpA2Ab5s3L8hYMfU2pwcwBbAUx2aww1SAGAj4FXjHl6ZQs+EFI32A8BkSbdL2jW1lkEihLBS0lXGpdOBrWLrcYMYkIVc/7ukQ1NrGVC+LemNXNlGks5OoMXJA1xcwbCqr4dYwOGJ27/MuI9LgQ1T6hp4gJOBdYNqELJFieEAwmMS6tgWeMe4l6el0jTwAEeM8k+pvUGALYFree++lkeB9RJq+g/jXj6C7zqMD9kOt9cKPvjWJql+NchJo2g/PaGm/UbR9KFUmgYSYHPgiYLmGALOb/Nve94gkgTcZ2hfTMKtw8CvDE0/SqVn4ADWB+4taA6AM4D9a2aQA7DnX3MSavqEoWc1sF0qTQMDWXTuDSXMcXHj87UyiCSRJZzI8wdg80R61gNeMDRdkELPQAFcWMIctwATGp+vo0Fmkg0f83w9oSYrFP7Z4f+D0wXIuu6iy7nzaRqP19EgkgRcZ3yHlcD2ifTsgL0g8tEUemoPcCDwVkFzLAK2ztVTV4NsO8r9SbbDDzu5w02p9NQWYAbwckFzLAf2NuqqpUEkCfi68T1Wk2ifOHCioedtYGoKPbUE2BQ7WdlYDAFHjVJfnQ2yGfYOvysS6ZmEHeX72W62OzCTHGB9ST+UtFfBj54TQvh5FyT1NCGEP0qyUu98HtgsgZ4hSbcYlz4VW0stIQujKMql49RZ2x5EGulxrdxf/5BIzyGGlrX4O5HOAOaUMMedwMRx6q21QSQJuML4PouBSQm0BOBpQ885sbXUBuAEsl+ZIjwETGmj7kEwyI7YmQ+7OvYfQ4+1FWFuCi19T+MBfrOgORbT5np/CoOQzaWigv12PUlULVmq0jxrgW1ia+lrgOnAiwXNsQLYt0Ab0QwCTAMuAeYxztCvashitCyOjqmjSc/jhpYzU2jpS4BNgAWFrJG9qf14wXa6bhBgAnAK713iPKNsfR3o+KXxvW6NraOh5WuGlntSaOk7gInA7W3b4l2+UKKtGAa50ajvZWDjsnWW1PFXho4hEiRSwO7Rhkiw/Nx3ANe0+dA2UyqlDHEMcjB2zNiFZessqWMCdlRt9BUkstUsK7v+SbG19BXAuW0+sM38hJLbSok0BwF+YNS5HNiyk3pL6LDCTx6OqaFJy9WGFs/AOBrAbNrfAjvMQjqI5SGeQWZg75X/Vif1ltCxG3Zv1vbCRoVa/tLQ8RK+X70Vsr3Lb7T5sA6zBNihw3ZjrmJdZdS7Ctip07oL6rDORrk8poaGjg3JQvDzfKDKdvo+FgvYVtJtkopMWt+WdHwI4ffdUdUV/lnSm7mySZKizkUk3WCUfZrI72dCCG9L+pVxaXal7ZT9IDBb0gmSdpAUdV0+x0xJRRIbr5N0Qgjhtk4bBvaX1E7v8FAI4YAK2rtI0ldzxasl7RpCeKHT+tvUsJmklyRNzl06LoRwRwwNTVq+KCk/zPxFCCHdRqpG1/bjNocWvch5Fd6LqG/SyYIHlxr1jxlUWTXYp2z9Z0wNDR17GDpWkiBOrFnU9W0+FL3ItRXfixShJtY++uVE3DgE/IWh4TXiv+EP2JvfDquqjUJzEGCmpCRBahVwj+qR/Pjbkt7KlW0q6fMRNdyr1uTSWyhysu8QArLnIUdW1UbRSfpHSnymF1go6aQQwprUQjolhLBMkjWc+SKRJsohhFWSrE1khUJ1KuJ+oyyZQaKHFVTAK5KODSGsSC2kQq5QttjQzPaS/jqiBmtCnsIg9xllh1Y13CtqkH57CfOOsuXc51MLqZIQwlPKDvfJc2pEGXdJWpsrmwXsFlGDJD0qaVmubGNJe1RReT8Ol9oFSaeFEP43tZAu8S9G2dFE2n4aQlgq6TfGpWNjtN+kg1F0fLCK+utskDkhhDrnTbpf0jO5somSPhNRQ68Ms+YZZW6QUXhB0skhBCsjR21o/HLeaFyKecCMZZDDiJ8NvmsGSXY4yjgsl3Riic8tkfR44+EZBG5Q9ma9+YduN+CgEII17KiUEMJC4EVlCwTDrC/pAEm/7Hb7TcxXNqRuniPvAUwJIeSXxAvRqwZZHUL4n9Qiep0QwnPA/ZI+nLv0adnj8m7wgKRP5soOU0SDhBBeAxZJ2rmpeKKyHGhW79I2dRxiDRpW8OBxEdt/wCir7E12AX5nlO3TaaVukP7nVklDubIdgY4fjjaxDHIo8Y8msAzSkk+5KG6QPqfxAtQKt4i1mrRArWEn0yTNitT+MI8YZd6DOJISLreGENbKHufHHmYtMMrcII4k2yAHEi+ZmjnMitT2MM8o2wjXzDTgfZ1U6gapASGEZyU9liueIOljkST82ig7MFLbkqQQwjpJTxuXZnZSrxukPtxplB0eqW1rv8vMWNHFTTxplHUUG+YGqQ9W2HeUeUAjBP/lXPEkSbvEaL+Jp4wy70EcSdkwJx8CP4t4ubMeN8oqiagtgPcgjk3jRKj8QxokHRxJQn4OJMU3iDUHmdFJhW6QemGdkxFrudXqQXaP1PYw1r6fjnKfuUHqhbWadEiktnuhB1mi1k1cWwH5FEVt4wapF9bmsD0jtW0ZZFbMTCeNnAP5xYIgaXrZOt0g9cJ6WbYlEY4oCCG8Iun1XPFkSe/vdts5rGyZpYdZbpAa0Qj7sJY6Yw11Fhll20ZqexjLIKW3IbtB6kfKucBLRllsg7xqlJXuQd0g9SPlalIvGOQ1o8wN4oxg9SCDZJClRpkbxBnBmoO0dax1BfSqQUpHE7hB6scSoyzWQ9oLBrGGWG4QZ4TXlJ0Z0szUSKl4esEgVorZ0icCu0FqRiPl0SvGpRibpyyDxNq0NUz+FC7JDeLkSPVL/kejLOp57mrdHy9Jm5StzA1ST1L9kuff4kutR7V1G+9BnHHJZzuXskN2ukrjTX5+/jMx8s5CyyBTKHk8tBuknrxjlMX6JU/Z9rBJ8wclTVDJLKJukHqScqhjtb1hpLaHyfdikhvEaWJge5AG1lF7pYZ5bpB6kvIh9R7E6XlSPqS92oO4QZwRrBWbQTkzpVLcIPXE+sW2ftm7gdVTxWp7GKu3KHUEuBuknqQ0iNW2NeTrJtaE3JqXjIsbpJ6k/BX3HsTpebwHacUN4owwsHOQRpqhfA+yTm4Qp4ktjDJrn0SljPJwrg0hlBr/l8QKTHyr7MnHbpB6YqW5sXYaVk0vzD+s0HYrBL4t3CD1xNr7YYXAV800o8yKru0mVg9SWoMbpGY0Tpe1jh2zdhlWTSpjNuMGccZkK7XOA/4QQoixktQLBrH2vfgQyxnB2jmYT+jcLXrBIFbvaWU6aQs3SP2wjhx7MVLbvWAQK8WPlSurLdwg9cM67sBKR9oNesEgVhZFN4gzgpVmdNAN4kMsZwTLIFa+3m6Qcv4zjBvEsWm8ybZOdY1lkJ2NshgvKJuxDuxZXLYyN0i92FWtcVhLQwilf0HbBdhG0ua54ndkH2jTTazTpEprcIPUiw8aZY9Gats6pOfxRhqeKDTyb+WXeZH3IE6Dw40y6+TbbpBy7jPMdEn5Q0NfDSGsKluhG6ReWGeiPxCp7ZSrZ8NYw6uO3gG5QWoCME3SrHyx7KOhu4E1xIrdg1gvSZ/rpEI3SH04VK3/z8dCCFae3m5gzkEitT2MZZAnOqnQDVIf/swoizL/ADaXtHWueEjS0zHab8Ja4raOpGsbN0h9ONYomxup7QOMsidDCKW2uXaAZZAnO6nQDVIDgF3UOsRZJ+meSBKs1bP5kdqWNPKSdBfjkvcgjo4zyuaFEGJskpLSrp4Ns4tat/wuCyGUDlSU3CB14eNG2R0xGgbWk3SQcSm2QT5glC3otFI3SJ8DTJU9xIliEEn7qnWb6+vqcPWoBHsbZb/rtFI3SP9zgloTpT0fQlgYqX1rePXrsml2OmAfo+yRTit1g/Q/nzXKbo/Yfi/MPyS7B+nYIKXOTIjA+sCfl/jcEmUBcgOR6h+YIfv9x/cjyjjUKIsV/yVJAraStFOueK2kjnvRXjXIVEk/L/nZF4A5IYSbqxTUo5yq1rNAHgsh/CZG48A+krbPFQ9J+m2M9puwopgXhhBWdlpxHYdY75f0X8CXUwvpJo1jjT9jXLohogxr9WxupBRDzVgGmVdFxXU0yDCXAn+TWkQX+ZBad/CtVdzhVbLl5RyWQSrpRetskCDpeuDg1EK6xLlG2c9CCFG2uALvk3SgcemuGO036ZggO9QliUH6bfI7WdKPgR1TC6kSYDfZsVffiyjjWLU+P4+HEDoK7SjBXmrNCfyGKgq1L2qQjl7bJ2JrSXcCVkrKfuU8tf7vnpd0a0QN1vAq5vLyMEcaZQ9WtdW3qEF+oSwIrt/YS9ItjbCIvqaxpHmKcenKWNGzwAaSrGX4FPMPyyD3V1V5IYM0us+YqyRV8jFJV6cWUQFnqTUob4Wk6yNqOEp2eEms3YuSRlbyjjAu3VdVG2Um6X8n6baqBETmTOC81CLK0hgmfsG4dF0IoesnSDVhLS/fFTODSYM91JrFZKUqfA9TeMjRWOM+HpitLA5oB7VmkojJTElFJuGXAc+EEPrR5OerNTnzaknXxBLQ2Ptuhdf/MJaGJo42yh4MIQxFV9KrANsCL1CMlYAVol207f3bbK/jXzRga+ANo+7vdlp3QR1nGRpeIctJFRXgZ4aWf4yto+cB9hvl4RmLJYCVJqZIuzENcrVR79uAlWqzawDzDB3fjKmhoWNK4/vn2Te2lr4AmA2safOBHWYh2X6Ksm1GMQgwA3gn9YMJ7DbK97NCzbut5VhDxxKyiXtl1OZNegjhbklF46/2lHQTvb/8+zVJG+TKVki6JLKO04yyh0MIHW9MKsFso+yngxLJXRrgmjZ/1Zu5smRbXe9BgEOAdUadXylbZ0kdE4DfGzr+PqaOhpaAPe88MbaWvgOYCNze5oPbjLV8Ol5bMQxyo1Hfy4B1mmvXAI43dKwCrCPPuq3loFG0lB4uDxTAJsCCNh/eYdYAVvjEWO3EMMgE4BTg1ab6Ti9bXwc65hrf60exdTS0XGJo+UkKLX0LMB14sW17ZKygwCoIcVexpjUejHlkOaCiARw4yvf6aEwdTXr+z9AS/Uej72k8wG8WsggsBvK75Maqvx0qe7NLmvcN/218pwVUvGLUppY9DS1rgHzq00qozSqWRQjhIWWBfUUCLLeTdBswpTuqOiOEsDpme8BOko43Ll2WaMXoU0bZAxGT5NUPYE7BXgTgTsYZypCgB4kNcJXxfV4EJiXQEoBnDT3RV9JqB3BtCZNcOk6dtTYI2bzHilA4P5GewwwtXRteDRTA+tixO+Pxt2PUWXeDXGB8lxXAZon0fMfQ89MUWmoJsCnwSEGDDAFHjVJfbQ0CbAa8bnyXyxPpmQQsNfRYm8ecspDFNb1c0CTLgZbMfTU3iPWuYYhE+/uBkww9K6nXVuregGxd/62CJllEbqxbV4MA241yf76TUNM9hp4fpNJTe4BPYMc4jcV8YKOmOupqkH81vsNKYHoiPTtgR2p/OIWegQG4sKBBAG4hy8VUS4OQhbSvNr7D1xJqusjQ8wwJXlQOFGTr6jeUMMnFjc/X0SC3GPqXkR3UmULPethRxL5zMAZky7/3ljDJGXUzCHAA9rBzTkJNnzT0rAa2S6Vp4AA2B54oaJAh4PyaGeR+Q/timuZdCTRZUcQpEkQMNsBM4LWCJml3i2/PGwR7GRUSRskCfzqKJisXltNtgCOw9353Sj8YZEuycJxm0z9Kwu3I2JvFHk6lx5EEnEzx5d++N8gwwCzg7obuYxLqmI79Y3VqKk1OA+DiQTXIMIB1cm7M9i837uOrwOSUuhyNLP9+f5ANkhKyRZMVxn38p9TanAbAZOABN0h8gK8a9/BNEiSIcMYA2AJ4yg0SD2Aj7Kjdb6XW5hiQTVqXuUHigP1uaYjIKVadAgBHkuVdcoN0EWBjskTYeaIm6HZKAHzODdJdgK8Y9241MDO1NqcNgG+4QboDMBV7B6P3Hv0C2fLvTW6Q6sF+97SKLO2Q0y8AGwIPukGqg2wHo5Xg79rU2pwSANsAzxcwyPzUmnsZ4LvGPXubNjNcOj0IsDdZMod2uDu13l4F2Ac7KnrMnGROHwAcg709Nc+XUmvtVbCTMSTbwehUDPahls08B2ySWmcv0viBsTg3tTanQoCzRxkmPAvsmVpfL0K213yhcc+eAfLHzTn9DrA72XuSO4CbgTNJuFW11yHbwbnIMIgfo+Y40kg60XN4N7R9Lp7Kx3HeC7A92fba/VJrcRzHcRzHcRzHcRzHcRzHcRzHcRzHcRzHcRzHcRzHcRzHcRzHcfqb/wc2OPBUELA+hQAAAABJRU5ErkJggg==</icon>
+  <description>Generates white noise.</description>
+  <link label="Wiki">http://phyphox.org/wiki/index.php?title=Experiment:_Tone_Generator</link>
+  <data-containers>
+    <container init="1">a</container>
+    <container size="4801" static="true">t</container>
+    <container size="4801">signal</container>
+  </data-containers>
+  <output>
+    <audio loop="true">
+      <noise>
+        <input parameter="amplitude">a</input>
+      </noise>
+    </audio>
+  </output>
+  <analysis onUserInput="true">
+    <ramp>
+      <input as="start" type="value">0</input>
+      <input as="stop" type="value">0.05</input>
+      <input as="length" type="value">4801</input>
+      <output>t</output>
+    </ramp>
+    <formula formula="[2]*(((7919*6959*(7907^[1_]) % 101)/101)*2-1)">
+      <input keep="true">t</input>
+      <input keep="true">a</input>
+      <output>signal</output>
+    </formula>
+  </analysis>
+  <views>
+    <view label="Noise">
+      <edit signed="false" min="0" max="1" default="1" label="Amplitude">
+        <output>a</output>
+      </edit>
+      <value label="Amplitude">
+        <input>a</input>
+      </value>
+      <graph label="Signal" labelX="Time" labelY="[[quantity_short_amplitude]]" unitX="[[unit_short_second]]" unitY="FS" scaleMinY="fixed" minY="-1" scaleMaxY="fixed" maxY="1">
+        <input axis="x">t</input>
+        <input color="orange" axis="y">signal</input>
+      </graph>
+      <separator height="1"/>
+      <info label="White noise shown above is simulated, not what will be played."/>
+    </view>
+  </views>
+  <export>
+    <set name="Signal">
+      <data name="Time (s)">t</data>
+      <data name="Signal sum">signal</data>
+    </set>
+  </export>
+</phyphox>


### PR DESCRIPTION
Wideband noise is useful to detect resonances in cavities.  Example: use at the mouth of a bottle.  Difference can be heard by ear, or by spectrum analyzer on another phone. Based on audio tone generator, created in the online editor.